### PR TITLE
Make interface to PostreSQL a development dependency

### DIFF
--- a/datafix.gemspec
+++ b/datafix.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "activerecord"
   gem.add_dependency "railties"
-  gem.add_dependency "pg"
 
+  gem.add_development_dependency "pg"
   gem.add_development_dependency "rspec", "~> 3.1"
   gem.add_development_dependency "database_cleaner"
   gem.add_development_dependency "rake"


### PR DESCRIPTION
While installing datafix in an older Rails app that used MySQL, I noticed that the process installed [`pg`](https://bitbucket.org/ged/ruby-pg/wiki/Home). After some digging, I noticed that the library is only needed by datafix's test suite.

As such, I have gone ahead and made the switch. Please let me know if there is some gotcha I am missing. After reviewing the library's source code this appears to be a safe fix, and the tests still pass, to boot :smile: