### PR TITLE
Update template to require rails_helper instead of spec_helper for Rspec >= 3.x

### DIFF
--- a/lib/generators/datafix/templates/datafix_spec_template.rb.erb
+++ b/lib/generators/datafix/templates/datafix_spec_template.rb.erb
@@ -1,4 +1,8 @@
+<%- if !defined?(RSpec::Version::STRING) || RSpec::Version::STRING.start_with?("1.") || RSpec::Version::STRING.start_with?("2.") -%>
 require "spec_helper"
+<%- else -%>
+require "rails_helper"
+<%- end -%>
 require Rails.root.join("db", "datafixes", "<%= "#{timestamp}_#{file_name}" %>")
 
 <%- if !defined?(RSpec::Version::STRING) || RSpec::Version::STRING.start_with?("1.") || RSpec::Version::STRING.start_with?("2.") -%>


### PR DESCRIPTION
https://github.com/rspec/rspec-rails/blob/master/Changelog.md#300--2014-06-01
